### PR TITLE
Add DailyShop economy option and reuse AFKPool config storage for AFKBlock upgrades

### DIFF
--- a/src/main/java/me/pizzalover/afkmania/gui/AFKBlock/AFKBlockGUI.java
+++ b/src/main/java/me/pizzalover/afkmania/gui/AFKBlock/AFKBlockGUI.java
@@ -3,6 +3,7 @@ package me.pizzalover.afkmania.gui.AFKBlock;
 import me.pizzalover.afkmania.Main;
 import me.pizzalover.afkmania.gui.guiUtils;
 import me.pizzalover.afkmania.utils.utils;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import xyz.xenondevs.invui.gui.Gui;
 import xyz.xenondevs.invui.window.Window;
@@ -14,8 +15,8 @@ public class AFKBlockGUI {
         String configPath = "gui";
         int slotAmount = Main.getAfkBlockConfig().getConfig().getInt(configPath + ".slot_amount");
 
-        if(slotAmount % 9 != 0) {
-            player.sendMessage(utils.translate( utils.addPlaceholderToText(player, Main.getMessageConfig().getConfig().getString("afk_block.gui.error_messages.slot_amount_not_divisible_by_9")
+        if (slotAmount % 9 != 0) {
+            player.sendMessage(utils.translate(utils.addPlaceholderToText(player, Main.getMessageConfig().getConfig().getString("afk_block.gui.error_messages.slot_amount_not_divisible_by_9")
                     .replace("%prefix%", Main.getSettingConfig().getConfig().getString("prefix"))
                     .replace("%gui%", Main.getAfkBlockConfig().getConfig().getString(configPath + ".gui_name"))
                     .replace("%slot_number%", String.valueOf(slotAmount))
@@ -23,16 +24,16 @@ public class AFKBlockGUI {
             return;
         }
 
-        if(slotAmount > 54) {
-            player.sendMessage(utils.translate( utils.addPlaceholderToText(player, Main.getMessageConfig().getConfig().getString("afk_block.gui.error_messages.slot_amount_greater_than_54")
+        if (slotAmount > 54) {
+            player.sendMessage(utils.translate(utils.addPlaceholderToText(player, Main.getMessageConfig().getConfig().getString("afk_block.gui.error_messages.slot_amount_greater_than_54")
                     .replace("%prefix%", Main.getSettingConfig().getConfig().getString("prefix"))
                     .replace("%gui%", Main.getAfkBlockConfig().getConfig().getString(configPath + ".gui_name"))
                     .replace("%slot_number%", String.valueOf(slotAmount))
             )));
             return;
         }
-        if(slotAmount < 9) {
-            player.sendMessage(utils.translate( utils.addPlaceholderToText(player, Main.getMessageConfig().getConfig().getString("afk_block.gui.error_messages.slot_amount_less_than_9")
+        if (slotAmount < 9) {
+            player.sendMessage(utils.translate(utils.addPlaceholderToText(player, Main.getMessageConfig().getConfig().getString("afk_block.gui.error_messages.slot_amount_less_than_9")
                     .replace("%prefix%", Main.getSettingConfig().getConfig().getString("prefix"))
                     .replace("%gui%", Main.getAfkBlockConfig().getConfig().getString(configPath + ".gui_name"))
                     .replace("%slot_number%", String.valueOf(slotAmount))
@@ -44,31 +45,46 @@ public class AFKBlockGUI {
         Gui gui = Gui.empty(9, height);
 
 
+        ConfigurationSection slotsSection = Main.getAfkBlockConfig().getConfig().getConfigurationSection(configPath + ".slots");
+        if (slotsSection != null) {
+            for (String slot : slotsSection.getKeys(false)) {
+                String path = configPath + ".slots." + slot + ".";
 
-        for(String slot : Main.getAfkBlockConfig().getConfig().getConfigurationSection(configPath + ".slots").getKeys(false)) {
-            String path = configPath + ".slots." + slot + ".";
+                int slotNum;
 
-            int slotNum;
+                try {
+                    slotNum = Integer.parseInt(slot);
+                } catch (NumberFormatException exception) {
+                    player.sendMessage(utils.translate(utils.addPlaceholderToText(player, Main.getMessageConfig().getConfig().getString("afk_block.gui.error_messages.invalid_slot_number")
+                            .replace("%prefix%", Main.getSettingConfig().getConfig().getString("prefix"))
+                            .replace("%gui%", Main.getAfkBlockConfig().getConfig().getString(configPath + ".gui_name"))
+                            .replace("%slot_number%", slot)
+                    )));
+                    continue;
+                }
 
-            try {
-                slotNum = Integer.parseInt(slot);
-            } catch (NumberFormatException exception) {
-                player.sendMessage(utils.translate( utils.addPlaceholderToText(player, Main.getMessageConfig().getConfig().getString("afk_block.gui.error_messages.invalid_slot_number")
-                        .replace("%prefix%", Main.getSettingConfig().getConfig().getString("prefix"))
-                        .replace("%gui%", Main.getAfkBlockConfig().getConfig().getString(configPath + ".gui_name"))
-                        .replace("%slot_number%", slot)
-                )));
-                continue;
+                gui.setItem(slotNum, guiUtils.createInventoryItem(player, path));
+
             }
+        }
 
-            gui.setItem(slotNum, guiUtils.createInventoryItem(player, path));
+        ConfigurationSection upgrades = Main.getAfkBlockConfig().getConfig().getConfigurationSection("upgrades");
+        if (upgrades != null) {
+            for (String key : upgrades.getKeys(false)) {
+                String path = "upgrades." + key + ".";
+                if (!Main.getAfkBlockConfig().getConfig().getBoolean(path + "enabled", false)) continue;
 
+                int slot = Main.getAfkBlockConfig().getConfig().getInt(path + "slot", -1);
+                if (slot < 0 || slot >= slotAmount) continue;
+
+                gui.setItem(slot, guiUtils.createUpgradeItem(player, key));
+            }
         }
 
         Window window = Window.single()
                 .setViewer(player)
                 .setGui(gui)
-                .setTitle(utils.translate( utils.addPlaceholderToText(player, Main.getAfkBlockConfig().getConfig().getString(configPath + ".gui_name"))))
+                .setTitle(utils.translate(utils.addPlaceholderToText(player, Main.getAfkBlockConfig().getConfig().getString(configPath + ".gui_name"))))
                 .build();
         window.open();
 

--- a/src/main/java/me/pizzalover/afkmania/gui/guiUtils.java
+++ b/src/main/java/me/pizzalover/afkmania/gui/guiUtils.java
@@ -2,6 +2,8 @@ package me.pizzalover.afkmania.gui;
 
 import com.cryptomorin.xseries.XMaterial;
 import me.pizzalover.afkmania.Main;
+import me.pizzalover.afkmania.modules.AFKBlockModules;
+import me.pizzalover.afkmania.player_info.afk_block.AFKBlockPlayerData;
 import me.pizzalover.afkmania.utils.SkullCreator;
 import me.pizzalover.afkmania.utils.utils;
 import org.bukkit.Bukkit;
@@ -21,48 +23,43 @@ import java.util.ArrayList;
 
 public class guiUtils {
 
-    /**
-     * Create an inventory item
-     * @param player The player
-     * @param path The path to the item in the config
-     * @return The item
-     */
     public static AbstractItem createInventoryItem(Player player, String path) {
         return new AbstractItem() {
             @Override
             public ItemProvider getItemProvider() {
-                if(Main.getAfkBlockConfig().getConfig().getString(path + "item").split("-")[0].equalsIgnoreCase("base64")) {
+                if (Main.getAfkBlockConfig().getConfig().getString(path + "item").split("-")[0].equalsIgnoreCase("base64")) {
                     String base64String = Main.getAfkBlockConfig().getConfig().getString(path + "item").replace("base64-", "");
-                    ItemStack base64Skull = SkullCreator.itemWithBase64(XMaterial.PLAYER_HEAD.parseItem(), base64String );
+                    ItemStack base64Skull = SkullCreator.itemWithBase64(XMaterial.PLAYER_HEAD.parseItem(), base64String);
                     SkullMeta base64SkullMeta = (SkullMeta) base64Skull.getItemMeta();
 
-                    base64SkullMeta.setDisplayName(utils.translate( utils.addPlaceholderToText(player, Main.getAfkBlockConfig().getConfig().getString(path + "name"))));
+                    base64SkullMeta.setDisplayName(utils.translate(utils.addPlaceholderToText(player, Main.getAfkBlockConfig().getConfig().getString(path + "name"))));
 
-                    ArrayList<String> lore = new ArrayList<>();
+                    ArrayList<String> lore = new ArrayList<String>();
 
-                    for(String s : Main.getAfkBlockConfig().getConfig().getStringList(path + "lore")) {
-                        for(String str : s.split("<br>"))
-                            lore.add(utils.translate( utils.addPlaceholderToText(player, str)));
+                    for (String s : Main.getAfkBlockConfig().getConfig().getStringList(path + "lore")) {
+                        for (String str : s.split("<br>"))
+                            lore.add(utils.translate(utils.addPlaceholderToText(player, str)));
                     }
                     base64SkullMeta.setLore(lore);
                     base64Skull.setItemMeta(base64SkullMeta);
 
                     return new ItemBuilder(base64Skull);
-                }
-                else if(Main.getAfkBlockConfig().getConfig().getString(path + "item").split("-")[0].equalsIgnoreCase("head")) {
+                } else if (Main.getAfkBlockConfig().getConfig().getString(path + "item").split("-")[0].equalsIgnoreCase("head")) {
                     ItemStack item = new ItemStack(Material.PLAYER_HEAD, 1);
                     SkullMeta pSkull = (SkullMeta) item.getItemMeta();
-                    pSkull.setDisplayName(utils.translate( utils.addPlaceholderToText(player, Main.getAfkBlockConfig().getConfig().getString(path + "name"))));
+                    pSkull.setDisplayName(utils.translate(utils.addPlaceholderToText(player, Main.getAfkBlockConfig().getConfig().getString(path + "name"))));
 
-                    ArrayList<String> lore = new ArrayList<>();
+                    ArrayList<String> lore = new ArrayList<String>();
 
-                    for(String s : Main.getAfkBlockConfig().getConfig().getStringList(path + "lore")) {
-                        for(String str : s.split("<br>"))
-                            lore.add(utils.translate( utils.addPlaceholderToText(player, str)));
+                    for (String s : Main.getAfkBlockConfig().getConfig().getStringList(path + "lore")) {
+                        for (String str : s.split("<br>"))
+                            lore.add(utils.translate(utils.addPlaceholderToText(player, str)));
                     }
                     pSkull.setLore(lore);
                     String playerName = Main.getAfkBlockConfig().getConfig().getString(path + "item").split("-")[1];
-                    if(playerName.contains("{")) {playerName = player.getName();}
+                    if (playerName.contains("{")) {
+                        playerName = player.getName();
+                    }
                     pSkull.setOwner(playerName);
                     item.setItemMeta(pSkull);
                     return new ItemBuilder(item);
@@ -70,12 +67,12 @@ public class guiUtils {
                 ItemStack itemStack = new ItemStack(XMaterial.valueOf(Main.getAfkBlockConfig().getConfig().getString(path + "item")).parseMaterial(), 1);
                 ItemMeta itemMeta = itemStack.getItemMeta();
 
-                itemMeta.setDisplayName(utils.translate( utils.addPlaceholderToText(player, Main.getAfkBlockConfig().getConfig().getString(path + "name"))));
+                itemMeta.setDisplayName(utils.translate(utils.addPlaceholderToText(player, Main.getAfkBlockConfig().getConfig().getString(path + "name"))));
 
-                ArrayList<String> lore = new ArrayList<>();
+                ArrayList<String> lore = new ArrayList<String>();
 
-                for(String s : Main.getAfkBlockConfig().getConfig().getStringList(path + "lore")) {
-                    for(String str : s.split("<br>"))
+                for (String s : Main.getAfkBlockConfig().getConfig().getStringList(path + "lore")) {
+                    for (String str : s.split("<br>"))
                         lore.add(utils.translate(utils.addPlaceholderToText(player, str)));
                 }
                 itemMeta.setLore(lore);
@@ -87,15 +84,15 @@ public class guiUtils {
             @Override
             public void handleClick(ClickType clickType, Player player, InventoryClickEvent inventoryClickEvent) {
 
-                if(clickType.isLeftClick()) {
-                    for(String s : Main.getAfkBlockConfig().getConfig().getStringList(path + "left_click_commands")) {
-                        if(s.startsWith("[player]")) {
+                if (clickType.isLeftClick()) {
+                    for (String s : Main.getAfkBlockConfig().getConfig().getStringList(path + "left_click_commands")) {
+                        if (s.startsWith("[player]")) {
                             player.performCommand(utils.addPlaceholderToText(player, s).replace("[player] ", ""));
                         } else if (s.startsWith("[console]")) {
                             utils.runConsoleCommand(utils.addPlaceholderToText(player, s).replace("[console] ", ""), player.getWorld());
                         } else if (s.startsWith("[sound]")) {
                             String[] soundVariables = s.replace("[sound] ", "").split(" ");
-                            player.playSound(player, Sound.valueOf(utils.addPlaceholderToText(player, soundVariables[0]) ), Integer.parseInt(soundVariables[1]), Integer.parseInt(soundVariables[2]));
+                            player.playSound(player, Sound.valueOf(utils.addPlaceholderToText(player, soundVariables[0])), Integer.parseInt(soundVariables[1]), Integer.parseInt(soundVariables[2]));
                         } else {
                             if (s.equalsIgnoreCase("exitInventory")) {
                                 player.closeInventory();
@@ -103,15 +100,15 @@ public class guiUtils {
                         }
                     }
                 }
-                if(clickType.isRightClick()) {
-                    for(String s : Main.getAfkBlockConfig().getConfig().getStringList(path + "right_click_commands")) {
-                        if(s.startsWith("[player]")) {
+                if (clickType.isRightClick()) {
+                    for (String s : Main.getAfkBlockConfig().getConfig().getStringList(path + "right_click_commands")) {
+                        if (s.startsWith("[player]")) {
                             player.performCommand(utils.addPlaceholderToText(player, s).replace("[player] ", ""));
                         } else if (s.startsWith("[console]")) {
                             Bukkit.dispatchCommand(Bukkit.getConsoleSender(), utils.addPlaceholderToText(player, s).replace("[console] ", ""));
                         } else if (s.startsWith("[sound]")) {
                             String[] soundVariables = s.replace("[sound] ", "").split(" ");
-                            player.playSound(player, Sound.valueOf(utils.addPlaceholderToText(player, soundVariables[0]) ), Integer.parseInt(soundVariables[1]), Integer.parseInt(soundVariables[2]));
+                            player.playSound(player, Sound.valueOf(utils.addPlaceholderToText(player, soundVariables[0])), Integer.parseInt(soundVariables[1]), Integer.parseInt(soundVariables[2]));
                         } else {
                             if (s.equalsIgnoreCase("exitInventory")) {
                                 player.closeInventory();
@@ -122,6 +119,133 @@ public class guiUtils {
 
             }
         };
+    }
+
+    public static AbstractItem createUpgradeItem(Player player, String upgradeKey) {
+        return new AbstractItem() {
+            @Override
+            public ItemProvider getItemProvider() {
+                AFKBlockModules module = (AFKBlockModules) Main.getModuleManager().getModule("AFKBlock");
+                AFKBlockPlayerData data = module.getOrCreatePlayerData(player);
+
+                String path = "upgrades." + upgradeKey + ".";
+                Material material = XMaterial.valueOf(Main.getAfkBlockConfig().getConfig().getString(path + "item", "STONE")).parseMaterial();
+                ItemStack item = new ItemStack(material == null ? Material.STONE : material, 1);
+                ItemMeta meta = item.getItemMeta();
+
+                int level = data.getUpgradeLevel(upgradeKey);
+                int maxLevel = Main.getAfkBlockConfig().getConfig().getInt(path + "max_level", 10);
+                long cost = getUpgradeCost(path, level);
+
+                String name = Main.getAfkBlockConfig().getConfig().getString(path + "name", "&e" + upgradeKey);
+                meta.setDisplayName(utils.translate(name
+                        .replace("%upgrade_level%", String.valueOf(level))
+                        .replace("%next_level%", String.valueOf(level + 1))
+                ));
+
+                ArrayList<String> lore = new ArrayList<String>();
+                for (String line : Main.getAfkBlockConfig().getConfig().getStringList(path + "lore")) {
+                    lore.add(utils.translate(utils.addPlaceholderToText(player, line)
+                            .replace("%upgrade_level%", String.valueOf(level))
+                            .replace("%next_level%", String.valueOf(level + 1))
+                            .replace("%upgrade_cost%", String.valueOf(cost))
+                            .replace("%upgrade_max_level%", String.valueOf(maxLevel))
+                    ));
+                }
+                meta.setLore(lore);
+                item.setItemMeta(meta);
+                return new ItemBuilder(item);
+            }
+
+            @Override
+            public void handleClick(ClickType clickType, Player player, InventoryClickEvent event) {
+                if (!clickType.isLeftClick()) return;
+
+                AFKBlockModules module = (AFKBlockModules) Main.getModuleManager().getModule("AFKBlock");
+                AFKBlockPlayerData data = module.getOrCreatePlayerData(player);
+                String path = "upgrades." + upgradeKey + ".";
+                int level = data.getUpgradeLevel(upgradeKey);
+                int maxLevel = Main.getAfkBlockConfig().getConfig().getInt(path + "max_level", 10);
+
+                if (level >= maxLevel) {
+                    for (String command : Main.getAfkBlockConfig().getConfig().getStringList(path + "maxed_commands")) {
+                        utils.runConsoleCommand(formatUpgradeCommand(command, player, upgradeKey, level, 0), player.getWorld());
+                    }
+                    return;
+                }
+
+                long cost = getUpgradeCost(path, level);
+                if (!chargeUpgradeCost(player, path, upgradeKey, level, cost)) {
+                    return;
+                }
+
+                data.setUpgradeLevel(upgradeKey, level + 1);
+                module.saveUpgrades(data);
+
+                for (String command : Main.getAfkBlockConfig().getConfig().getStringList(path + "after_purchase_commands")) {
+                    utils.runConsoleCommand(formatUpgradeCommand(command, player, upgradeKey, level + 1, cost), player.getWorld());
+                }
+
+                event.getWhoClicked().closeInventory();
+                Bukkit.getScheduler().runTaskLater(Main.getInstance(), new Runnable() {
+                    @Override
+                    public void run() {
+                        me.pizzalover.afkmania.gui.AFKBlock.AFKBlockGUI.openUpgradeGUI(player);
+                    }
+                }, 1L);
+            }
+        };
+    }
+
+    private static boolean chargeUpgradeCost(Player player, String upgradePath, String upgradeKey, int level, long cost) {
+        String economyType = Main.getAfkBlockConfig().getConfig().getString("economy.type", "COMMAND").toUpperCase();
+
+        if ("NONE".equalsIgnoreCase(economyType)) {
+            return true;
+        }
+
+        String balancePlaceholder = Main.getAfkBlockConfig().getConfig().getString("economy.balance_placeholder", "%vault_eco_balance_fixed%");
+        if (!balancePlaceholder.isEmpty()) {
+            try {
+                String balanceText = utils.addPlaceholderToText(player, balancePlaceholder).replace(",", "").trim();
+                double balance = Double.parseDouble(balanceText);
+                if (balance < cost) {
+                    for (String command : Main.getAfkBlockConfig().getConfig().getStringList("economy.insufficient_funds_commands")) {
+                        utils.runConsoleCommand(formatUpgradeCommand(command, player, upgradeKey, level, cost), player.getWorld());
+                    }
+                    return false;
+                }
+            } catch (Exception ignored) {
+            }
+        }
+
+        String chargePath;
+        if ("DAILYSHOP".equalsIgnoreCase(economyType)) {
+            chargePath = "economy.dailyshop_charge_commands";
+        } else {
+            chargePath = upgradePath + "purchase_commands";
+        }
+
+        for (String command : Main.getAfkBlockConfig().getConfig().getStringList(chargePath)) {
+            utils.runConsoleCommand(formatUpgradeCommand(command, player, upgradeKey, level, cost), player.getWorld());
+        }
+
+        return true;
+    }
+
+    private static String formatUpgradeCommand(String command, Player player, String upgradeKey, int currentLevel, long cost) {
+        return utils.addPlaceholderToText(player, command)
+                .replace("%player%", player.getName())
+                .replace("%upgrade%", upgradeKey)
+                .replace("%upgrade_level%", String.valueOf(currentLevel))
+                .replace("%next_upgrade_level%", String.valueOf(currentLevel + 1))
+                .replace("%upgrade_cost%", String.valueOf(cost));
+    }
+
+    private static long getUpgradeCost(String path, int currentLevel) {
+        long baseCost = Main.getAfkBlockConfig().getConfig().getLong(path + "base_cost", 0);
+        long incrementalCost = Main.getAfkBlockConfig().getConfig().getLong(path + "incremental_cost", 0);
+        return Math.max(0, baseCost + (incrementalCost * currentLevel));
     }
 
 }

--- a/src/main/java/me/pizzalover/afkmania/listeners/AFKBlockPlayerInteract.java
+++ b/src/main/java/me/pizzalover/afkmania/listeners/AFKBlockPlayerInteract.java
@@ -25,27 +25,15 @@ public class AFKBlockPlayerInteract implements Listener {
         Player player = event.getPlayer();
         AFKBlockModules afkBlockModules = (AFKBlockModules) Main.getModuleManager().getModule("AFKBlock");
 
-        AFKBlockPlayerData playerData = null;
+        AFKBlockPlayerData playerData = afkBlockModules.getPlayerData(player);
 
-        for(AFKBlockPlayerData tempPlayerData : afkBlockModules.player_data_afk_block) {
-            if(tempPlayerData.getPlayer().getUniqueId().equals(player.getUniqueId())) {
-                playerData = tempPlayerData;
-                break;
-            }
-        }
-
-        if(playerData == null) {
+        if (playerData == null) {
             return;
         }
 
         playerData.getPlayer().resetTitle();
-
-
-        BlockState blockstate = afkBlockModules.getBlockLocation().getBlock().getState().copy();
-        blockstate.setType(XMaterial.valueOf(Main.getAfkBlockConfig().getConfig().getString("block_settings.original_block")).parseMaterial());
-
-        playerData.getPlayer().sendBlockChange(afkBlockModules.getBlockLocation(), blockstate.getBlockData());
-
+        restoreDefaultBlock(playerData, afkBlockModules);
+        afkBlockModules.saveUpgrades(playerData);
         afkBlockModules.player_data_afk_block.remove(playerData);
     }
 
@@ -54,7 +42,7 @@ public class AFKBlockPlayerInteract implements Listener {
         Block block = event.getBlock();
 
         AFKBlockModules afkBlockModules = (AFKBlockModules) Main.getModuleManager().getModule("AFKBlock");
-        if(block.getLocation().equals(afkBlockModules.getBlockLocation())) {
+        if (block.getLocation().equals(afkBlockModules.getBlockLocation())) {
             event.setCancelled(true);
         }
     }
@@ -63,38 +51,27 @@ public class AFKBlockPlayerInteract implements Listener {
     public void onPlayerInteract(PlayerInteractEvent event) {
 
 
-        if(event.getClickedBlock() == null) {
+        if (event.getClickedBlock() == null) {
             return;
         }
 
         Player player = event.getPlayer();
         AFKBlockModules afkBlockModules = (AFKBlockModules) Main.getModuleManager().getModule("AFKBlock");
 
-        if(!event.getClickedBlock().getLocation().equals(afkBlockModules.getBlockLocation())) {
+        if (!event.getClickedBlock().getLocation().equals(afkBlockModules.getBlockLocation())) {
             return;
         }
 
-        if(event.getAction() == Action.LEFT_CLICK_BLOCK) {
-
-            AFKBlockPlayerData playerData = null;
-
-            for (AFKBlockPlayerData tempPlayerData : afkBlockModules.player_data_afk_block) {
-                if (tempPlayerData.getPlayer().getUniqueId().equals(player.getUniqueId())) {
-                    playerData = tempPlayerData;
-                    break;
-                }
-            }
-
+        if (event.getAction() == Action.LEFT_CLICK_BLOCK) {
+            AFKBlockPlayerData playerData = afkBlockModules.getPlayerData(player);
             if (playerData != null) {
                 return;
             }
 
-            playerData = new AFKBlockPlayerData(player, 0);
-            afkBlockModules.player_data_afk_block.add(playerData);
-        } else if(event.getAction() == Action.RIGHT_CLICK_BLOCK) {
+            afkBlockModules.getOrCreatePlayerData(player);
+        } else if (event.getAction() == Action.RIGHT_CLICK_BLOCK) {
 
-            // Open GUI
-            player.sendMessage(utils.translate( utils.addPlaceholderToText(player, Main.getInstance().getMessageConfig().getConfig().getString("afk_block.gui.opening_gui")
+            player.sendMessage(utils.translate(utils.addPlaceholderToText(player, Main.getInstance().getMessageConfig().getConfig().getString("afk_block.gui.opening_gui")
                     .replace("%prefix%", Main.getInstance().getSettingConfig().getConfig().getString("prefix"))
             )));
             AFKBlockGUI.openUpgradeGUI(player);
@@ -107,17 +84,10 @@ public class AFKBlockPlayerInteract implements Listener {
         Player player = event.getPlayer();
         AFKBlockModules afkBlockModules = (AFKBlockModules) Main.getModuleManager().getModule("AFKBlock");
 
-        if(player.getLocation().distance(afkBlockModules.getBlockLocation()) > Main.getAfkBlockConfig().getConfig().getInt("block_settings.block_distance")) {
-            AFKBlockPlayerData playerData = null;
+        if (player.getLocation().distance(afkBlockModules.getBlockLocation()) > Main.getAfkBlockConfig().getConfig().getInt("block_settings.block_distance")) {
+            AFKBlockPlayerData playerData = afkBlockModules.getPlayerData(player);
 
-            for(AFKBlockPlayerData tempPlayerData : afkBlockModules.player_data_afk_block) {
-                if(tempPlayerData.getPlayer().getUniqueId().equals(player.getUniqueId())) {
-                    playerData = tempPlayerData;
-                    break;
-                }
-            }
-
-            if(playerData == null) {
+            if (playerData == null) {
                 return;
             }
 
@@ -134,13 +104,17 @@ public class AFKBlockPlayerInteract implements Listener {
                     10,
                     5);
 
-
-            BlockState blockstate = afkBlockModules.getBlockLocation().getBlock().getState().copy();
-            blockstate.setType(XMaterial.valueOf(Main.getAfkBlockConfig().getConfig().getString("block_settings.original_block")).parseMaterial());
-
-            playerData.getPlayer().sendBlockChange(afkBlockModules.getBlockLocation(), blockstate.getBlockData());
+            restoreDefaultBlock(playerData, afkBlockModules);
+            afkBlockModules.saveUpgrades(playerData);
             afkBlockModules.player_data_afk_block.remove(playerData);
         }
+    }
+
+    private void restoreDefaultBlock(AFKBlockPlayerData playerData, AFKBlockModules afkBlockModules) {
+        BlockState blockstate = afkBlockModules.getBlockLocation().getBlock().getState().copy();
+        blockstate.setType(XMaterial.valueOf(Main.getAfkBlockConfig().getConfig().getString("block_settings.original_block")).parseMaterial());
+
+        playerData.getPlayer().sendBlockChange(afkBlockModules.getBlockLocation(), blockstate.getBlockData());
     }
 
 }

--- a/src/main/java/me/pizzalover/afkmania/modules/AFKBlockModules.java
+++ b/src/main/java/me/pizzalover/afkmania/modules/AFKBlockModules.java
@@ -12,11 +12,11 @@ import me.pizzalover.afkmania.utils.utils;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.BlockState;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Random;
+import java.util.*;
 
 public class AFKBlockModules implements ModuleInterface {
 
@@ -30,7 +30,6 @@ public class AFKBlockModules implements ModuleInterface {
 
     public MyScheduledTask afkMessageTask;
     public MyScheduledTask afkBlockTask;
-    public MyScheduledTask afkBlockMining;
 
     @Override
     public boolean isEnabled() {
@@ -50,17 +49,15 @@ public class AFKBlockModules implements ModuleInterface {
     @Override
     public void enable() {
 
-        if(!Main.getAfkBlockConfig().getConfigFile().exists()) {
+        if (!Main.getAfkBlockConfig().getConfigFile().exists()) {
             Main.getInstance().saveResource("modules/afk_block.yml", false);
         }
-        Main.getAfkBlockConfig().updateConfig(Arrays.asList("gui", "block_settings.hologram", "upgrades"));
+        Main.getAfkBlockConfig().updateConfig(Arrays.asList("gui", "block_settings.hologram", "upgrades", "rewards", "blocks"));
 
         Main.getAfkBlockConfig().saveConfig();
         Main.getAfkBlockConfig().reloadConfig();
 
-
-        // Check if DecentHolograms is installed
-        if(Main.getInstance().getServer().getPluginManager().getPlugin("DecentHolograms") == null) {
+        if (Main.getInstance().getServer().getPluginManager().getPlugin("DecentHolograms") == null) {
             Main.getInstance().getLogger().severe("DecentHolograms is not installed! Disabling AFKBlock module...");
             Main.getModuleManager().disableModule(this);
             return;
@@ -70,42 +67,33 @@ public class AFKBlockModules implements ModuleInterface {
         Main.getInstance().getServer().getPluginManager().registerEvents(afkBlockPlayerInteract, Main.getInstance());
         player_data_afk_block = new ArrayList<>();
 
-        // Load the block location for holograms and that...
         blockLocation = new Location(
                 Main.getInstance().getServer().getWorld(Main.getAfkBlockConfig().getConfig().getString("block_location.world")),
                 Main.getAfkBlockConfig().getConfig().getDouble("block_location.x"),
                 Main.getAfkBlockConfig().getConfig().getDouble("block_location.y"),
                 Main.getAfkBlockConfig().getConfig().getDouble("block_location.z")
-        );
-        blockLocation = blockLocation.getBlock().getLocation();
-
+        ).getBlock().getLocation();
 
         hologramLocation = blockLocation.clone();
         hologramLocation.add(hologramLocation.getX() > 0 ? -0.5 : 0.5, 1, hologramLocation.getZ() > 0 ? -0.5 : 0.5);
 
-        // Load the hologram lines
         ArrayList<String> hologramLines = new ArrayList<>();
-        for(String hologram_lines : Main.getAfkBlockConfig().getConfig().getStringList("block_settings.hologram")) {
+        for (String hologram_lines : Main.getAfkBlockConfig().getConfig().getStringList("block_settings.hologram")) {
             hologramLocation.add(0, 0.3, 0);
             hologramLines.add(utils.translate(hologram_lines));
         }
 
-        // Create the hologram
         blockHologram = DHAPI.createHologram("AFKBlock", getHologramLocation(), false, hologramLines);
 
-
-
-        // Handles the AFK title messages
         afkMessageTask = Main.getScheduler().runTaskTimerAsynchronously(() -> {
-            for(AFKBlockPlayerData playerData : player_data_afk_block) {
-                if(playerData.getPlayer().getInventory().firstEmpty() == -1) {
+            for (AFKBlockPlayerData playerData : player_data_afk_block) {
+                if (playerData.getPlayer().getInventory().firstEmpty() == -1) {
                     playerData.getPlayer().sendTitle(utils.translate(Main.getAfkBlockConfig().getConfig().getString("afk-message.inventory-full.title")),
                             utils.translate(Main.getAfkBlockConfig().getConfig().getString("afk-message.inventory-full.subtitle")),
                             0,
                             5,
                             5
                     );
-                    continue;
                 } else {
                     playerData.getPlayer().sendTitle(utils.translate(Main.getAfkBlockConfig().getConfig().getString("afk-message.inventory-collect.title")),
                             utils.translate(Main.getAfkBlockConfig().getConfig().getString("afk-message.inventory-collect.subtitle")),
@@ -115,72 +103,252 @@ public class AFKBlockModules implements ModuleInterface {
                     );
                 }
             }
-        }, 0, 1L);
+        }, 0, 20L);
 
-        // Adds 1 to the AFKBlockTime every second
-        afkBlockTask = Main.getScheduler().runTaskTimerAsynchronously(() -> {
-            for(AFKBlockPlayerData playerData : player_data_afk_block) {
+        afkBlockTask = Main.getScheduler().runTaskTimer(() -> {
+            for (AFKBlockPlayerData playerData : player_data_afk_block) {
                 playerData.setAFKBlockTimeTicks(playerData.getAFKBlockTimeTicks() + 1);
 
-                if(playerData.getAFKBlockTimeTicks() % (Main.getAfkBlockConfig().getConfig().getDouble("block_settings.break_speed")*20) == 0) {
-                    playerData.getPlayer().playSound(playerData.getPlayer().getLocation(), "block.break", 1, 1);
+                double effectiveBreakSpeed = getEffectiveBreakSpeed(playerData);
+                if (effectiveBreakSpeed <= 0) effectiveBreakSpeed = 0.1;
 
-                    BlockState blockstate = getBlockLocation().getBlock().getState().copy();
-
-                    ArrayList<Material> materialList = new ArrayList<>();
-                    for(String blocks : Main.getAfkBlockConfig().getConfig().getStringList("blocks")) {
-                        Material material = XMaterial.valueOf(blocks).parseMaterial();
-                        materialList.add(material);
-                    }
-
-                    if(materialList.size() == 0) {
-                        Main.getInstance().getLogger().severe("No blocks found in the config! Disabling AFKBlock module...");
-                        Main.getModuleManager().disableModule(this);
-                        return;
-                    }
-
-                    int randomIndex = new Random().nextInt(materialList.size());
-                    blockstate.setType(materialList.get(randomIndex));
-
-
-                    playerData.getPlayer().sendBlockChange(getBlockLocation(), blockstate.getBlockData());
-
+                if (playerData.getAFKBlockTimeTicks() % Math.max(1, (int) (effectiveBreakSpeed * 20)) == 0) {
+                    rewardPlayer(playerData.getPlayer(), playerData);
+                    updateVisualBlock(playerData);
                 }
-
             }
         }, 20L, 1L);
 
-        // Mining task, switch the block every time it changes and reward the player...
-        afkBlockMining = Main.getScheduler().runTaskTimerAsynchronously(() -> {
-            for(AFKBlockPlayerData playerData : player_data_afk_block) {
+    }
 
-//                block_settings:
-//                break_speed: 1
-
-
+    public AFKBlockPlayerData getPlayerData(Player player) {
+        for (AFKBlockPlayerData playerData : player_data_afk_block) {
+            if (playerData.getPlayer().getUniqueId().equals(player.getUniqueId())) {
+                return playerData;
             }
-        }, 0, 1L);
+        }
+        return null;
+    }
 
+    public AFKBlockPlayerData getOrCreatePlayerData(Player player) {
+        AFKBlockPlayerData data = getPlayerData(player);
+        if (data != null) {
+            return data;
+        }
+
+        data = new AFKBlockPlayerData(player, 0);
+        loadUpgrades(player, data);
+        player_data_afk_block.add(data);
+        updateVisualBlock(data);
+        return data;
+    }
+
+    private void loadUpgrades(Player player, AFKBlockPlayerData data) {
+        ConfigurationSection section = Main.getAfkPoolsConfig().getConfig().getConfigurationSection("afk_block_upgrades." + player.getUniqueId() + ".upgrades");
+        if (section == null) return;
+
+        for (String key : section.getKeys(false)) {
+            data.setUpgradeLevel(key, section.getInt(key, 0));
+        }
+    }
+
+    public void saveUpgrades(AFKBlockPlayerData data) {
+        String basePath = "afk_block_upgrades." + data.getPlayer().getUniqueId() + ".upgrades";
+        for (Map.Entry<String, Integer> entry : data.getUpgradeLevels().entrySet()) {
+            Main.getAfkPoolsConfig().getConfig().set(basePath + "." + entry.getKey(), entry.getValue());
+        }
+        Main.getAfkPoolsConfig().saveConfig();
+        Main.getAfkPoolsConfig().reloadConfig();
+    }
+
+    private void updateVisualBlock(AFKBlockPlayerData data) {
+        BlockState blockstate = getBlockLocation().getBlock().getState().copy();
+        blockstate.setType(getRandomBlockMaterial());
+        data.getPlayer().sendBlockChange(getBlockLocation(), blockstate.getBlockData());
+        data.getPlayer().playSound(data.getPlayer().getLocation(), "block.stone.break", 1, 1);
+    }
+
+    private Material getRandomBlockMaterial() {
+        ConfigurationSection blocksSection = Main.getAfkBlockConfig().getConfig().getConfigurationSection("blocks");
+
+        if (blocksSection != null) {
+            List<WeightedEntry<Material>> weightedMaterials = new ArrayList<>();
+            for (String key : blocksSection.getKeys(false)) {
+                String matName = blocksSection.getString(key + ".material", "STONE");
+                Material material;
+                try {
+                    material = XMaterial.valueOf(matName.toUpperCase()).parseMaterial();
+                } catch (Exception e) {
+                    material = Material.STONE;
+                }
+                int weight = Math.max(1, blocksSection.getInt(key + ".weight", 1));
+                weightedMaterials.add(new WeightedEntry<Material>(material, weight));
+            }
+            Material selected = selectWeighted(weightedMaterials);
+            return selected == null ? Material.STONE : selected;
+        }
+
+        ArrayList<Material> materialList = new ArrayList<Material>();
+        for (String blocks : Main.getAfkBlockConfig().getConfig().getStringList("blocks")) {
+            Material material = XMaterial.valueOf(blocks).parseMaterial();
+            if (material != null) materialList.add(material);
+        }
+
+        if (materialList.size() == 0) {
+            return Material.STONE;
+        }
+
+        int randomIndex = new Random().nextInt(materialList.size());
+        return materialList.get(randomIndex);
+    }
+
+    private void rewardPlayer(Player player, AFKBlockPlayerData playerData) {
+        ConfigurationSection rewardsSection = Main.getAfkBlockConfig().getConfig().getConfigurationSection("rewards");
+        if (rewardsSection == null) {
+            return;
+        }
+
+        Material rolledBlock = getRandomBlockMaterial();
+        List<String> rewardPool = getRewardPoolForBlock(rolledBlock);
+
+        List<WeightedEntry<String>> rewards = new ArrayList<WeightedEntry<String>>();
+        for (String key : rewardsSection.getKeys(false)) {
+            if (!rewardPool.isEmpty() && !rewardPool.contains(key)) {
+                continue;
+            }
+            int chance = rewardsSection.getInt(key + ".chance", 1);
+            if (chance <= 0) continue;
+            rewards.add(new WeightedEntry<String>(key, chance));
+        }
+
+        String selectedRewardKey = selectWeighted(rewards);
+        if (selectedRewardKey == null) {
+            return;
+        }
+
+        String rewardPath = "rewards." + selectedRewardKey + ".";
+        List<String> commands = Main.getAfkBlockConfig().getConfig().getStringList(rewardPath + "commands");
+        if (commands.isEmpty()) {
+            String singleCommand = Main.getAfkBlockConfig().getConfig().getString(rewardPath + "command", "");
+            if (!singleCommand.isEmpty()) commands = Collections.singletonList(singleCommand);
+        }
+
+        int amount = Main.getAfkBlockConfig().getConfig().getInt(rewardPath + "amount", 1);
+        int fortuneLevel = playerData.getUpgradeLevel("fortune");
+        int extraItems = (int) Math.floor(Math.random() * (fortuneLevel + 1));
+        int finalAmount = Math.max(1, amount + extraItems);
+
+        for (String command : commands) {
+            String built = applyPlaceholders(command, player, selectedRewardKey, finalAmount, playerData);
+            utils.runConsoleCommand(built, player.getWorld());
+        }
+
+        runUpgradeProcHooks(player, playerData, selectedRewardKey);
+    }
+
+    private List<String> getRewardPoolForBlock(Material material) {
+        ConfigurationSection blocksSection = Main.getAfkBlockConfig().getConfig().getConfigurationSection("blocks");
+        if (blocksSection == null) return Collections.emptyList();
+
+        for (String key : blocksSection.getKeys(false)) {
+            String matName = blocksSection.getString(key + ".material", "STONE");
+            Material configured;
+            try {
+                configured = XMaterial.valueOf(matName.toUpperCase()).parseMaterial();
+            } catch (Exception e) {
+                configured = Material.STONE;
+            }
+
+            if (configured == material) {
+                return Main.getAfkBlockConfig().getConfig().getStringList("blocks." + key + ".rewards");
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    private void runUpgradeProcHooks(Player player, AFKBlockPlayerData playerData, String rewardKey) {
+        ConfigurationSection upgrades = Main.getAfkBlockConfig().getConfig().getConfigurationSection("upgrades");
+        if (upgrades == null) return;
+
+        for (String upgradeKey : upgrades.getKeys(false)) {
+            String path = "upgrades." + upgradeKey + ".";
+            if (!Main.getAfkBlockConfig().getConfig().getBoolean(path + "enabled", false)) continue;
+
+            int level = playerData.getUpgradeLevel(upgradeKey);
+            if (level <= 0) continue;
+
+            double chancePerLevel = Main.getAfkBlockConfig().getConfig().getDouble(path + "chance_per_level", 0);
+            double procChance = Math.min(100.0, chancePerLevel * level);
+            if (new Random().nextDouble() * 100 > procChance) continue;
+
+            for (String command : Main.getAfkBlockConfig().getConfig().getStringList(path + "proc_commands")) {
+                String built = applyPlaceholders(command, player, rewardKey, 1, playerData)
+                        .replace("%upgrade%", upgradeKey)
+                        .replace("%upgrade_level%", String.valueOf(level));
+                utils.runConsoleCommand(built, player.getWorld());
+            }
+        }
+    }
+
+    private String applyPlaceholders(String command, Player player, String rewardKey, int amount, AFKBlockPlayerData data) {
+        return utils.addPlaceholderToText(player, command)
+                .replace("%player%", player.getName())
+                .replace("%reward%", rewardKey)
+                .replace("%amount%", String.valueOf(amount))
+                .replace("%afk_block_seconds%", String.valueOf((int) data.getAFKBlockTimeSeconds()));
+    }
+
+    private double getEffectiveBreakSpeed(AFKBlockPlayerData playerData) {
+        double base = Main.getAfkBlockConfig().getConfig().getDouble("block_settings.break_speed", 1D);
+        int hasteLevel = playerData.getUpgradeLevel("haste");
+        double reductionPerLevel = Main.getAfkBlockConfig().getConfig().getDouble("upgrades.haste.break_speed_reduction_per_level", 0D);
+
+        double computed = base - (hasteLevel * reductionPerLevel);
+        double minValue = Main.getAfkBlockConfig().getConfig().getDouble("upgrades.haste.minimum_break_speed", 0.2D);
+
+        return Math.max(minValue, computed);
+    }
+
+    private <T> T selectWeighted(List<WeightedEntry<T>> entries) {
+        if (entries == null || entries.isEmpty()) return null;
+
+        int total = 0;
+        for (WeightedEntry<T> entry : entries) {
+            total += Math.max(0, entry.weight);
+        }
+
+        if (total <= 0) return null;
+
+        int random = new Random().nextInt(total);
+        int index = 0;
+        for (WeightedEntry<T> entry : entries) {
+            index += Math.max(0, entry.weight);
+            if (random < index) {
+                return entry.value;
+            }
+        }
+        return null;
     }
 
     @Override
     public void disable() {
-        if(Main.getInstance().getServer().getPluginManager().getPlugin("DecentHolograms") != null) {
+        if (Main.getInstance().getServer().getPluginManager().getPlugin("DecentHolograms") != null) {
             if (blockHologram != null)
                 blockHologram.delete();
         }
-        if(afkBlockPlayerInteract != null)
+        if (afkBlockPlayerInteract != null)
             HandlerList.unregisterAll(afkBlockPlayerInteract);
-        if(player_data_afk_block != null) {
+        if (player_data_afk_block != null) {
+            for (AFKBlockPlayerData data : player_data_afk_block) {
+                saveUpgrades(data);
+            }
             player_data_afk_block.clear();
             player_data_afk_block = null;
         }
-        if(afkMessageTask != null)
+        if (afkMessageTask != null)
             afkMessageTask.cancel();
-        if(afkBlockTask != null)
+        if (afkBlockTask != null)
             afkBlockTask.cancel();
-        if(afkBlockMining != null)
-            afkBlockMining.cancel();
 
     }
 
@@ -193,51 +361,37 @@ public class AFKBlockModules implements ModuleInterface {
 
     }
 
-    /**
-     * Get the block location
-     * @return the block location
-     */
     public Location getBlockLocation() {
         return blockLocation;
     }
 
-    /**
-     * Set the block location
-     * @param blockLocation the block location
-     */
     public void setBlockLocation(Location blockLocation) {
         this.blockLocation = blockLocation;
     }
 
-    /**
-     * Get the block hologram
-     * @return the block hologram
-     */
     public Hologram getBlockHologram() {
         return blockHologram;
     }
 
-    /**
-     * Set the block hologram
-     * @param blockHologram the block hologram
-     */
     public void setBlockHologram(Hologram blockHologram) {
         this.blockHologram = blockHologram;
     }
 
-    /**
-     * Get the hologram location
-     * @return the hologram location
-     */
     public Location getHologramLocation() {
         return hologramLocation;
     }
 
-    /**
-     * Set the hologram location
-     * @param hologramLocation the hologram location
-     */
     public void setHologramLocation(Location hologramLocation) {
         this.hologramLocation = hologramLocation;
+    }
+
+    static class WeightedEntry<T> {
+        final T value;
+        final int weight;
+
+        WeightedEntry(T value, int weight) {
+            this.value = value;
+            this.weight = weight;
+        }
     }
 }

--- a/src/main/java/me/pizzalover/afkmania/player_info/afk_block/AFKBlockPlayerData.java
+++ b/src/main/java/me/pizzalover/afkmania/player_info/afk_block/AFKBlockPlayerData.java
@@ -2,10 +2,14 @@ package me.pizzalover.afkmania.player_info.afk_block;
 
 import org.bukkit.entity.Player;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class AFKBlockPlayerData {
 
     Player player;
     int afk_block_time;
+    private final Map<String, Integer> upgradeLevels;
 
     /**
      * Constructor for the player data afk pool
@@ -15,6 +19,7 @@ public class AFKBlockPlayerData {
     public AFKBlockPlayerData(Player player, int afk_block_time) {
         this.player = player;
         this.afk_block_time = afk_block_time;
+        this.upgradeLevels = new HashMap<>();
     }
 
     /**
@@ -54,7 +59,18 @@ public class AFKBlockPlayerData {
      * @return the afk pool time of the player in seconds
      */
     public float getAFKBlockTimeSeconds() {
-        return afk_block_time/20;
+        return afk_block_time / 20f;
     }
 
+    public int getUpgradeLevel(String upgradeKey) {
+        return upgradeLevels.getOrDefault(upgradeKey.toLowerCase(), 0);
+    }
+
+    public void setUpgradeLevel(String upgradeKey, int level) {
+        upgradeLevels.put(upgradeKey.toLowerCase(), Math.max(level, 0));
+    }
+
+    public Map<String, Integer> getUpgradeLevels() {
+        return upgradeLevels;
+    }
 }

--- a/src/main/resources/modules/afk_block.yml
+++ b/src/main/resources/modules/afk_block.yml
@@ -3,7 +3,7 @@ block_location:
   y: 0
   z: 0
   world: world
-reward_interval_seconds: 5
+
 afk-message:
   inventory-collect:
     title: "&6AFK Block"
@@ -21,58 +21,159 @@ afk-message:
 block_settings:
   original_block: STONE
   block_distance: 6
-  break_speed: 1 # Time in seconds to break each block
+  break_speed: 1
   hologram:
-    - "Line 1"
-    - "Line 2"
-    - "Line 3"
+    - "&6&lAFK BLOCK"
+    - "&7Left click to start mining"
+    - "&7Right click for upgrades"
+
+# Advanced block table for prison servers.
+# Each node can define material, weight, and reward pool.
+blocks:
+  stone:
+    material: STONE
+    weight: 35
+    rewards: ["tokens_small", "money_small"]
+  coal:
+    material: COAL_ORE
+    weight: 25
+    rewards: ["tokens_small", "money_small", "key_frag"]
+  diamond:
+    material: DIAMOND_ORE
+    weight: 10
+    rewards: ["tokens_big", "money_big", "crate_key"]
+
+# Weighted reward table. Multiple commands are supported for plugin hook compatibility.
+rewards:
+  tokens_small:
+    chance: 50
+    amount: 1
+    commands:
+      - "eco give %player% 250"
+      - "tokens give %player% 5"
+  money_small:
+    chance: 35
+    amount: 1
+    commands:
+      - "eco give %player% 500"
+  key_frag:
+    chance: 10
+    amount: 1
+    commands:
+      - "cc give p fragment 1 %player%"
+  tokens_big:
+    chance: 15
+    amount: 1
+    commands:
+      - "eco give %player% 2000"
+      - "tokens give %player% 35"
+  money_big:
+    chance: 12
+    amount: 1
+    commands:
+      - "eco give %player% 3500"
+  crate_key:
+    chance: 5
+    amount: 1
+    commands:
+      - "cc give p vote 1 %player%"
+
+
+# Economy bridge for upgrade purchases.
+# type: COMMAND, DAILYSHOP, NONE
+# - COMMAND uses each upgrade's purchase_commands
+# - DAILYSHOP uses economy.dailyshop_charge_commands for every upgrade
+# - NONE skips charging
+# balance_placeholder can use PlaceholderAPI (leave empty to skip pre-check)
+economy:
+  type: DAILYSHOP
+  balance_placeholder: "%dailyshop_balance%"
+  dailyshop_charge_commands:
+    - "dailyshop take %player% %upgrade_cost%"
+  insufficient_funds_commands:
+    - "msg %player% &cYou need $%upgrade_cost% to buy this upgrade."
 
 gui:
-  gui_name: "AFK Block"
+  gui_name: "&8AFK Block Upgrades"
   slot_amount: 27
   slots:
-    0:
-      # the item
-      item: "POTATO"
-      # item display name
-      name: "&b&lPotato"
-      # item lore
+    11:
+      item: "BOOK"
+      name: "&e&lHow It Works"
       lore:
-        - "Lore one"
-        - "Lore two"
-      # left click commands
+        - "&7Purchase upgrades and keep mining"
+        - "&7while AFK in this area."
       left_click_commands:
-        - "[console] give %player_username% diamond 1"
-      # right click commands
+        - "[sound] ENTITY_EXPERIENCE_ORB_PICKUP 1 2"
       right_click_commands:
-        - "[console] give %player_username% dirt 1"
+        - "[sound] ENTITY_EXPERIENCE_ORB_PICKUP 1 2"
 
 upgrades:
   fortune:
-    name: "" # How it displays in the GUI
-    slot: 0 # What slot position it should appear
+    name: "&bFortune &7(Level %upgrade_level%)"
+    slot: 13
     enabled: true
     item: DIAMOND
     lore:
-      - "line 1"
-      - "line 2"
-    chance_per_level: 1 # 1 = 1%
-    base_cost: 100
-    incremental_cost:
-    max_level:
-  keyfinder:
-    name: "" # How it displays in the GUI
-    slot: 0 # What slot position it should appear
-    enabled: false
-    item: DIAMOND
-    lore:
-      - "line 1"
-      - "line 2"
-    chance_per_level: 1 # 1 = 1%
-    base_cost: 100
-    incremental_cost:
-    max_level:
+      - "&7Adds bonus amount to rewards."
+      - "&7Current: &f%upgrade_level%"
+      - "&7Next Cost: &e$%upgrade_cost%"
+      - "&8Max: %upgrade_max_level%"
+    chance_per_level: 0
+    base_cost: 1000
+    incremental_cost: 1500
+    max_level: 25
+    purchase_commands:
+      - "eco take %player% %upgrade_cost%"
+    after_purchase_commands:
+      - "msg %player% &aUpgraded Fortune to level %next_upgrade_level%!"
+      - "playsound minecraft:entity.player.levelup player %player%"
+    maxed_commands:
+      - "msg %player% &cThis upgrade is already maxed."
+    proc_commands: []
 
-blocks:
-  - DIAMOND_ORE
-  - EMERALD_ORE
+  keyfinder:
+    name: "&dKey Finder &7(Level %upgrade_level%)"
+    slot: 14
+    enabled: true
+    item: TRIPWIRE_HOOK
+    lore:
+      - "&7Chance to trigger key commands"
+      - "&7on each AFK break."
+      - "&7Proc Chance: &f%upgrade_level%%"
+      - "&7Next Cost: &e$%upgrade_cost%"
+    chance_per_level: 1
+    base_cost: 3000
+    incremental_cost: 3000
+    max_level: 100
+    purchase_commands:
+      - "eco take %player% %upgrade_cost%"
+    after_purchase_commands:
+      - "msg %player% &aUpgraded Key Finder to level %next_upgrade_level%!"
+    maxed_commands:
+      - "msg %player% &cThis upgrade is already maxed."
+    proc_commands:
+      - "cc give p minekey 1 %player%"
+
+  haste:
+    name: "&6Haste &7(Level %upgrade_level%)"
+    slot: 15
+    enabled: true
+    item: SUGAR
+    lore:
+      - "&7Reduces AFK block break speed."
+      - "&7Current level: &f%upgrade_level%"
+      - "&7Next Cost: &e$%upgrade_cost%"
+    chance_per_level: 0
+    break_speed_reduction_per_level: 0.03
+    minimum_break_speed: 0.2
+    base_cost: 2000
+    incremental_cost: 2500
+    max_level: 20
+    purchase_commands:
+      - "eco take %player% %upgrade_cost%"
+    after_purchase_commands:
+      - "msg %player% &aUpgraded Haste to level %next_upgrade_level%!"
+    maxed_commands:
+      - "msg %player% &cThis upgrade is already maxed."
+    proc_commands: []


### PR DESCRIPTION
### Motivation
- Integrate AFKBlock upgrades with external economy systems (notably DailyShop) so servers can charge upgrades via existing shop commands without code changes. 
- Reuse AFKPool’s existing config storage to centralize per-player upgrade persistence and avoid a separate AFKBlock data file. 
- Improve upgrade purchase flow so a charge step is performed before increasing a player’s upgrade level. 

### Description
- Added an economy bridge with `economy.type` (`DAILYSHOP`, `COMMAND`, `NONE`), `economy.balance_placeholder`, `economy.dailyshop_charge_commands`, and `economy.insufficient_funds_commands` to `modules/afk_block.yml`. 
- Implemented `chargeUpgradeCost`, `formatUpgradeCommand`, and `getUpgradeCost` in `guiUtils` and wired upgrade purchase to only proceed when charging succeeds, supporting DailyShop and command-based charging. 
- Switched AFKBlock upgrade persistence to use AFKPool’s config manager (`Main.getAfkPoolsConfig().getConfig()`) under `afk_block_upgrades.<uuid>.upgrades` and removed the separate `modules/afk_block_data.yml` usage in `AFKBlockModules`. 
- Added/cleaned up AFK block runtime and GUI integrations including `createUpgradeItem`, upgrade click handling, weighted block/reward selection, placeholder application, upgrade proc hooks, `getEffectiveBreakSpeed`, and refined listener/player-data helpers; also added per-player `upgradeLevels` storage in `AFKBlockPlayerData`. 

### Testing
- Attempted a package build with `mvn -q -DskipTests package` to validate compilation and packaging, but the build failed due to Maven Central returning HTTP 403 for `maven-resources-plugin` resolution so packaging could not be completed in this environment. 
- Confirmed source edits and a commit were created for `AFKBlockModules.java`, `guiUtils.java`, and `modules/afk_block.yml` via repository status checks and commit output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a931634348326bc6a655a3ea292c5)